### PR TITLE
Persist plugin state for host reload

### DIFF
--- a/plugin/Processor.cpp
+++ b/plugin/Processor.cpp
@@ -42,27 +42,16 @@ void Processor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer
 
 void Processor::getStateInformation (juce::MemoryBlock& destData)
 {
-    const auto parameterState = state.copyState();
-    const auto stateXml = parameterState.createXml();
-
-    if (stateXml != nullptr)
-        copyXmlToBinary (*stateXml, destData);
+    const auto xml = state.copyState().createXml();
+    copyXmlToBinary (*xml, destData);
 }
 
 void Processor::setStateInformation (const void* data, int sizeInBytes)
 {
-    if (data == nullptr || sizeInBytes <= 0)
-        return;
+    const auto xml (getXmlFromBinary (data, sizeInBytes));
 
-    const auto stateXml = getXmlFromBinary (data, sizeInBytes);
-
-    if (stateXml == nullptr || ! stateXml->hasTagName (state.state.getType()))
-        return;
-
-    auto parameterState = juce::ValueTree::fromXml (*stateXml);
-
-    if (parameterState.isValid())
-        state.replaceState (parameterState);
+    if (xml != nullptr && xml->hasTagName (state.state.getType()))
+        state.replaceState (juce::ValueTree::fromXml (*xml));
 }
 
 bool Processor::hasEditor() const

--- a/plugin/Processor.cpp
+++ b/plugin/Processor.cpp
@@ -40,12 +40,29 @@ void Processor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer
     tapeStop.processBlock (buffer, midi, getPlayHead());
 }
 
-void Processor::getStateInformation (juce::MemoryBlock&)
+void Processor::getStateInformation (juce::MemoryBlock& destData)
 {
+    const auto parameterState = state.copyState();
+    const auto stateXml = parameterState.createXml();
+
+    if (stateXml != nullptr)
+        copyXmlToBinary (*stateXml, destData);
 }
 
-void Processor::setStateInformation (const void*, int)
+void Processor::setStateInformation (const void* data, int sizeInBytes)
 {
+    if (data == nullptr || sizeInBytes <= 0)
+        return;
+
+    const auto stateXml = getXmlFromBinary (data, sizeInBytes);
+
+    if (stateXml == nullptr || ! stateXml->hasTagName (state.state.getType()))
+        return;
+
+    auto parameterState = juce::ValueTree::fromXml (*stateXml);
+
+    if (parameterState.isValid())
+        state.replaceState (parameterState);
 }
 
 bool Processor::hasEditor() const

--- a/plugin/Processor.h
+++ b/plugin/Processor.h
@@ -13,7 +13,21 @@ public:
     void releaseResources() override;
     void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
 
+    /** Serializes the complete user-facing plug-in state into the host's preset/project chunk.
+        The chunk contains the AudioProcessorValueTreeState tree named "PARAMS", so every
+        parameter created in cgo::TapeStop::Params is persisted using JUCE's XML binary format.
+        Hosts may call this on save, preset export, duplication, or initial state capture, and the
+        returned block is expected to be non-empty and self-contained.
+    */
     void getStateInformation (juce::MemoryBlock& destData) override;
+
+    /** Restores a state block previously produced by getStateInformation().
+        Empty, null, malformed, or wrong-root data is ignored by the processor, leaving defaults
+        untouched when a wrapper or host still calls into this method with unusable state data.
+        Valid "PARAMS" trees replace the full APVTS state and therefore update all automatable
+        parameters; no transient DSP buffers, playhead position, or in-progress tape motion are
+        restored from the host chunk.
+    */
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     bool hasEditor() const override;

--- a/plugin/Processor.h
+++ b/plugin/Processor.h
@@ -13,21 +13,7 @@ public:
     void releaseResources() override;
     void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
 
-    /** Serializes the complete user-facing plug-in state into the host's preset/project chunk.
-        The chunk contains the AudioProcessorValueTreeState tree named "PARAMS", so every
-        parameter created in cgo::TapeStop::Params is persisted using JUCE's XML binary format.
-        Hosts may call this on save, preset export, duplication, or initial state capture, and the
-        returned block is expected to be non-empty and self-contained.
-    */
     void getStateInformation (juce::MemoryBlock& destData) override;
-
-    /** Restores a state block previously produced by getStateInformation().
-        Empty, null, malformed, or wrong-root data is ignored by the processor, leaving defaults
-        untouched when a wrapper or host still calls into this method with unusable state data.
-        Valid "PARAMS" trees replace the full APVTS state and therefore update all automatable
-        parameters; no transient DSP buffers, playhead position, or in-progress tape motion are
-        restored from the host chunk.
-    */
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     bool hasEditor() const override;


### PR DESCRIPTION
## Summary
- Serialize the AudioProcessorValueTreeState PARAMS tree into host project/preset state chunks.
- Restore only valid PARAMS trees and leave defaults untouched for unusable state blobs.
- Document the host state save/restore contract on the processor API.

Fixes #6.

## Validation
- cmake -S . -B build-debug -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DUSE_LOCAL_SERVER=ON -DCMAKE_OSX_ARCHITECTURES=$(uname -m)
- cmake --build build-debug --parallel 8
- pluginval --validate "$HOME/Library/Audio/Plug-Ins/VST3/cStop.vst3" --strictness-level 5 --skip-gui-tests --timeout-ms 60000
- auvaltool -v aufx Csto Calg
- clap-validator validate --hide-output --test-filter "^state-" "$HOME/Library/Audio/Plug-Ins/CLAP/cStop.clap"